### PR TITLE
Improve Sudoku UX and styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "lock-game",
+  "name": "minigames",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "lock-game",
+      "name": "minigames",
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",

--- a/src/App.css
+++ b/src/App.css
@@ -49,6 +49,18 @@
   max-width: 600px;
 }
 
+.options select,
+.options button {
+  padding: 0.5rem 1rem;
+}
+
+@media (min-width: 1024px) {
+  .options select,
+  .options button {
+    font-size: 1.25rem;
+  }
+}
+
 .attempt-text {
   font-size: 1rem;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,10 +30,10 @@ function DigitWheel({ value, onChange, disabled }) {
 
 export default function App() {
   const [screen, setScreen] = useState('start')
-  const [gameType, setGameType] = useState('lock') // lock or sudoku
+  const [gameType, setGameType] = useState('sudoku') // lock or sudoku
   const [mode, setMode] = useState('easy') // 'easy' or 'challenge'
   const [difficulty, setDifficulty] = useState('easy') // lock difficulty
-  const [sudokuDifficulty, setSudokuDifficulty] = useState('easy')
+  const [sudokuDifficulty, setSudokuDifficulty] = useState('hard')
 
   const [codeLength, setCodeLength] = useState(4)
   const [maxAttempts, setMaxAttempts] = useState(10)
@@ -149,8 +149,8 @@ export default function App() {
           <div>
             <label>Oyun: </label>
             <select value={gameType} onChange={(e) => setGameType(e.target.value)}>
-              <option value="lock">Lock Game</option>
               <option value="sudoku">Sudoku</option>
+              <option value="lock">Lock Game</option>
             </select>
           </div>
           {gameType === 'lock' && (
@@ -176,9 +176,9 @@ export default function App() {
             <div>
               <label>Zorluk: </label>
               <select value={sudokuDifficulty} onChange={(e) => setSudokuDifficulty(e.target.value)}>
-                <option value="easy">5x5 Kolay</option>
-                <option value="medium">9x9 Orta</option>
                 <option value="hard">9x9 Zor</option>
+                <option value="medium">9x9 Orta</option>
+                <option value="easy">5x5 Kolay</option>
               </select>
             </div>
           )}

--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -55,13 +55,18 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  opacity: 0.2;
 }
 .note-cell.readonly span {
   cursor: default;
-  opacity: 0.6;
+  opacity: 0.2;
+}
+.note-cell.readonly {
+  pointer-events: none;
 }
 .note-cell span.active {
-  color: red;
+  color: #2196f3;
+  opacity: 1;
 }
 .note-btn {
   background: red;
@@ -76,9 +81,27 @@
   justify-content: center;
   gap: 0.5rem;
 }
+
+.end-controls {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
 .status {
   margin-top: 0.5rem;
   font-weight: bold;
+}
+
+.finished .board {
+  opacity: 0.6;
+  animation: winflash 0.5s ease-in-out;
+}
+
+@keyframes winflash {
+  from { transform: scale(1); }
+  50% { transform: scale(1.05); }
+  to { transform: scale(1); }
 }
 
 .note-mode {
@@ -101,6 +124,10 @@
   }
   .board input {
     font-size: 2rem;
+  }
+  .controls button,
+  .end-controls button {
+    font-size: 1.25rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- update start screen defaults to show Sudoku first
- enlarge option controls for desktop
- tweak Sudoku note editing to avoid input blocking
- add note fixing buttons and restart controls
- style finished board and notes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688686cd83348327bae58cd1d5e9ddda