### PR TITLE
Improve Sudoku usability and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minigames",
-  "version": "0.0.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minigames",
-      "version": "0.0.0",
+      "version": "0.1.2",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.css
+++ b/src/App.css
@@ -52,6 +52,8 @@
 .options select,
 .options button {
   padding: 0.5rem 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
 @media (min-width: 1024px) {
@@ -69,6 +71,11 @@
   opacity: 0.5;
   font-size: 0.8rem;
   margin-top: 2rem;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  text-align: center;
 }
 
 @media (max-width: 600px) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -184,7 +184,7 @@ export default function App() {
           )}
           <button onClick={startGame}>Başla</button>
         </div>
-        <footer className="footer">Mustafa Evleksiz Tarafından geliştirilmiştir v{version}</footer>
+        <footer className="footer">Developed by Mustafa Evleksiz v{version}</footer>
       </div>
     )
   }
@@ -192,7 +192,7 @@ export default function App() {
   if (screen === 'sudoku') {
     return (
       <div className="app">
-        <SudokuGame difficulty={sudokuDifficulty} onBack={handleRestart} />
+        <SudokuGame difficulty={sudokuDifficulty} version={version} onBack={handleRestart} />
       </div>
     )
   }
@@ -230,7 +230,7 @@ export default function App() {
           </div>
         ))}
       </div>
-      <footer className="footer">Mustafa Evleksiz Tarafından geliştirilmiştir v{version}</footer>
+      <footer className="footer">Developed by Mustafa Evleksiz v{version}</footer>
     </div>
     )
   }

--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -35,6 +35,7 @@
   font-size: 1.5rem;
   background: transparent;
   color: inherit;
+  outline: none;
 }
 .prefilled {
   font-weight: bold;
@@ -74,6 +75,28 @@
 }
 .note-btn.active {
   background: darkred;
+}
+.note-btn.inactive {
+  opacity: 0.6;
+}
+.active-cell {
+  outline: 2px solid #2196f3;
+}
+.digit-pad {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  z-index: 500;
+}
+.digit-pad button {
+  width: 2.5rem;
+  height: 2.5rem;
 }
 .controls {
   margin-top: 0.5rem;


### PR DESCRIPTION
## Summary
- generate a randomized puzzle on each Sudoku game start
- add secret header hint activation with five clicks
- clear notes when hints fill a cell
- highlight editing cell and show keypad overlay
- show footer during Sudoku play and fix it to bottom
- style form controls better
- update copyright string
- bump version to 0.1.2

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688690dd69e48327ac60bc2ea8bd7752