### PR TITLE
Enhance Sudoku mobile layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minigames",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minigames",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -3,9 +3,14 @@
   animation: fadein 0.5s ease-in;
 }
 
+.sudoku h1 {
+  margin: 0.1rem 0;
+  font-size: 1.4rem;
+}
+
 .board {
   border-collapse: collapse;
-  margin: 1rem auto;
+  margin: 0.5rem auto;
 }
 .board.size9 td:nth-child(3n) {
   border-right: 3px solid #333;
@@ -21,11 +26,15 @@
 }
 .board td {
   border: 1px solid #333;
-  width: 3rem;
-  height: 3rem;
+  width: 3.3rem;
+  height: 3.3rem;
   text-align: center;
   color: #000;
   position: relative;
+  transition: background-color 0.3s;
+}
+.board td:active {
+  background-color: #e0e0e0;
 }
 .board input {
   width: 100%;
@@ -85,31 +94,51 @@
 }
 .active-cell {
   outline: 2px solid #2196f3;
+  animation: pulse 1s infinite;
 }
 .digit-pad {
   position: fixed;
   bottom: 0;
   left: 0;
   width: 100%;
-  background: rgba(0, 0, 0, 0.8);
-  display: flex;
-  justify-content: center;
+  background: rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(8px);
+  border-top: 1px solid rgba(255, 255, 255, 0.4);
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
   gap: 0.5rem;
-  flex-wrap: wrap;
   padding: 0.5rem;
   z-index: 500;
 }
 .digit-pad button {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 100%;
+  height: 3rem;
+  transition: transform 0.2s;
 }
 .digit-pad button:disabled {
   opacity: 0.5;
+}
+.digit-pad button:active {
+  transform: scale(0.9);
 }
 
 @media (min-width: 768px) {
   .digit-pad {
     display: none;
+  }
+}
+
+@media (max-width: 600px) {
+  .board td {
+    width: 2.6rem;
+    height: 2.6rem;
+  }
+  .board input {
+    font-size: 1.4rem;
+  }
+  .digit-pad button {
+    width: 100%;
+    height: 2.8rem;
   }
 }
 .controls {
@@ -196,4 +225,9 @@
   .prefilled {
     color: inherit;
   }
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.1); }
 }

--- a/src/SudokuGame.jsx
+++ b/src/SudokuGame.jsx
@@ -330,7 +330,7 @@ export default function SudokuGame({ difficulty, onBack, version }) {
             onPointerDown={e => e.preventDefault()}
             onClick={() => handleChange(activeCell.r, activeCell.c, '')}
           >
-            X
+            {'<'}
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
- compress Sudoku heading spacing
- move board upward and enlarge cells
- redesign digit pad as glassy grid with two rows
- bump version to 0.1.8

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68869dd6d1f48327b129d9b991560e0e