### PR TITLE
Adjust board theming and UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,8 @@
 .app {
   text-align: center;
   font-family: sans-serif;
-  padding: 2rem;
-  min-height: 100vh;
+  padding: 1rem;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -81,7 +81,7 @@
 .footer {
   opacity: 0.5;
   font-size: 0.8rem;
-  margin-top: 2rem;
+  margin-top: 0.5rem;
   position: fixed;
   bottom: 0;
   left: 0;
@@ -91,7 +91,7 @@
 
 .sudoku-app {
   justify-content: flex-start;
-  padding-top: 1rem;
+  padding-top: 0.5rem;
 }
 
 @media (max-width: 600px) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,8 @@ export default function App() {
   const [mode, setMode] = useState('easy') // 'easy' or 'challenge'
   const [difficulty, setDifficulty] = useState('easy') // lock difficulty
   const [sudokuDifficulty, setSudokuDifficulty] = useState('hard')
+  const [theme, setTheme] = useState('glass')
+  const [palette, setPalette] = useState('gs')
 
   const [codeLength, setCodeLength] = useState(4)
   const [maxAttempts, setMaxAttempts] = useState(10)
@@ -41,6 +43,10 @@ export default function App() {
   const [guess, setGuess] = useState([])
   const [attempts, setAttempts] = useState([])
   const [status, setStatus] = useState('')
+
+  useEffect(() => {
+    document.body.className = `theme-${theme} palette-${palette}`
+  }, [theme, palette])
 
   const finished = status !== ''
 
@@ -144,7 +150,7 @@ export default function App() {
   if (screen === 'start') {
     return (
       <div className="app">
-        <h1>Oyun Seçimi</h1>
+        <h1>MiniGames</h1>
         <div className="options">
           <div>
             <label>Oyun: </label>
@@ -182,6 +188,23 @@ export default function App() {
               </select>
             </div>
           )}
+          <div>
+            <label>Tema: </label>
+            <select value={theme} onChange={(e) => setTheme(e.target.value)}>
+              <option value="glass">Bulanık Cam</option>
+              <option value="metal">Metal</option>
+            </select>
+          </div>
+          <div>
+            <label>Renk Paleti: </label>
+            <select value={palette} onChange={(e) => setPalette(e.target.value)}>
+              <option value="gs">Galatasaray</option>
+              <option value="bjk">Beşiktaş</option>
+              <option value="fb">Fenerbahçe</option>
+              <option value="ts">Trabzon</option>
+              <option value="tr">Türkiye</option>
+            </select>
+          </div>
           <button onClick={startGame}>Başla</button>
         </div>
         <footer className="footer">Developed by Mustafa Evleksiz v{version}</footer>
@@ -212,8 +235,8 @@ export default function App() {
       </div>
       <div className="lock-controls">
         {!finished && <button onClick={handleSubmit}>Tahmin Et</button>}
-        {finished && <button onClick={handleRestart}>Yeniden Başlat</button>}
-        <button onClick={handleRestart}>Ana Sayfa</button>
+        {finished && <button className="icon-btn" onClick={handleRestart}>🔄</button>}
+        <button className="icon-btn" onClick={handleRestart}>🏠</button>
       </div>
       <p>Kalan Hak: {maxAttempts - attempts.length}</p>
       {status && <p className="status">{status}</p>}

--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -14,8 +14,8 @@
 .board {
   border-collapse: collapse;
   margin: 0.5rem auto;
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(6px);
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(10px);
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.2);
 }
@@ -36,7 +36,8 @@
   width: 3.3rem;
   height: 3.3rem;
   text-align: center;
-  color: #000;
+  color: #fff;
+  text-shadow: 0 0 3px #000;
   position: relative;
   transition: background-color 0.3s;
 }
@@ -50,7 +51,8 @@
   border: none;
   font-size: 1.5rem;
   background: transparent;
-  color: inherit;
+  color: #fff;
+  text-shadow: 0 0 3px #000;
   outline: none;
 }
 .board input:disabled {
@@ -90,13 +92,16 @@
   opacity: 1;
 }
 .note-btn {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  color: var(--gs-yellow);
+  background: transparent;
+  border: 1px solid var(--secondary);
+  font-size: 1.4rem;
+  padding: 0.4em;
+  border-radius: 8px;
+  color: var(--secondary);
 }
 .note-btn.active {
-  color: var(--gs-red);
+  background: var(--primary);
+  color: #fff;
 }
 .note-btn.inactive {
   opacity: 0.6;
@@ -121,7 +126,7 @@
   height: 3rem;
   transition: transform 0.2s;
   border-radius: 8px;
-  background: var(--gs-red);
+  background: var(--primary);
   color: #fff;
   border: none;
 }
@@ -156,6 +161,14 @@
   display: flex;
   justify-content: center;
   gap: 0.5rem;
+}
+.controls button,
+.end-controls button {
+  width: 2.2rem;
+  height: 2.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .end-controls {
@@ -193,6 +206,12 @@
   transform: translate(-50%, -50%);
 }
 
+.note-mode .pen-cursor {
+  border: 2px solid var(--secondary);
+  border-radius: 50%;
+  box-sizing: border-box;
+}
+
 @media (min-width: 1024px) {
   .board td {
     width: 4rem;
@@ -207,12 +226,13 @@
   }
 }
 
+
 .block0,
 .block2,
 .block4,
 .block6,
 .block8 {
-  background: rgba(253, 185, 18, 0.3);
+  background: var(--block-light);
   color: #000;
 }
 
@@ -220,7 +240,7 @@
 .block3,
 .block5,
 .block7 {
-  background: rgba(169, 4, 50, 0.5);
+  background: var(--block-dark);
   color: #fff;
 }
 

--- a/src/SudokuGame.jsx
+++ b/src/SudokuGame.jsx
@@ -354,21 +354,27 @@ export default function SudokuGame({ difficulty, onBack, version }) {
           ))}
         </tbody>
       </table>
-      <div className="controls">
-        <button
-          className={`note-btn${noteMode ? ' active' : ' inactive'}`}
-          onClick={() => setNoteMode(!noteMode)}
-        >
-          ✏️
-        </button>
-        {superMode && (
-          <button onClick={fixAllNotes}>Notları Düzelt</button>
-        )}
-        <button onClick={giveHint} disabled={!superMode && hintsLeft <= 0}>
-          Ipucu ({superMode ? '∞' : hintsLeft})
-        </button>
-        <button onClick={onBack}>Ana Sayfa / Ayarlar</button>
-      </div>
+      {!finished && (
+        <div className="controls">
+          <button
+            className={`icon-btn note-btn${noteMode ? ' active' : ' inactive'}`}
+            onClick={() => setNoteMode(!noteMode)}
+          >
+            ✏️
+          </button>
+          {superMode && (
+            <button className="icon-btn" onClick={fixAllNotes}>📝</button>
+          )}
+          <button
+            className="icon-btn"
+            onClick={giveHint}
+            disabled={!superMode && hintsLeft <= 0}
+          >
+            💡 ({superMode ? '∞' : hintsLeft})
+          </button>
+          <button className="icon-btn" onClick={onBack}>🏠</button>
+        </div>
+      )}
       {activeCell && (
         <div className="digit-pad">
           {(() => {
@@ -395,8 +401,8 @@ export default function SudokuGame({ difficulty, onBack, version }) {
       {finished && <p className="status">Tebrikler!</p>}
       {finished && (
         <div className="end-controls">
-          <button onClick={restartGame}>Yeniden Başla</button>
-          <button onClick={onBack}>Ana Sayfa</button>
+          <button className="icon-btn" onClick={restartGame}>🔄</button>
+          <button className="icon-btn" onClick={onBack}>🏠</button>
         </div>
       )}
       {noteMode && (
@@ -404,7 +410,7 @@ export default function SudokuGame({ difficulty, onBack, version }) {
           src={pen}
           alt="pen"
           className="pen-cursor"
-          style={{ left: mouse.x + 8, top: mouse.y + 8 }}
+          style={{ left: mouse.x, top: mouse.y }}
         />
       )}
       <footer className="footer">Developed by Mustafa Evleksiz v{version}</footer>

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,10 @@
 
   --gs-red: #a90432;
   --gs-yellow: #fdb913;
+  --primary: var(--gs-red);
+  --secondary: var(--gs-yellow);
+  --block-light: rgba(253, 185, 18, 0.3);
+  --block-dark: rgba(169, 4, 50, 0.5);
 
   color-scheme: light dark;
   color: #f0f0f0;
@@ -31,8 +35,51 @@ body {
   align-items: center;
   justify-content: center;
   min-width: 320px;
-  min-height: 100vh;
-  background: linear-gradient(135deg, var(--gs-red), var(--gs-yellow));
+  min-height: 100dvh;
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
+}
+
+.palette-gs {
+  --primary: var(--gs-red);
+  --secondary: var(--gs-yellow);
+  --block-light: rgba(253, 185, 18, 0.3);
+  --block-dark: rgba(169, 4, 50, 0.5);
+}
+
+.palette-bjk {
+  --primary: #000000;
+  --secondary: #ffffff;
+  --block-light: rgba(255, 255, 255, 0.3);
+  --block-dark: rgba(0, 0, 0, 0.5);
+}
+
+.palette-fb {
+  --primary: #0b5aa1;
+  --secondary: #ffcb00;
+  --block-light: rgba(255, 203, 0, 0.3);
+  --block-dark: rgba(11, 90, 161, 0.5);
+}
+
+.palette-ts {
+  --primary: #7d1a3b;
+  --secondary: #4e97a8;
+  --block-light: rgba(78, 151, 168, 0.3);
+  --block-dark: rgba(125, 26, 59, 0.5);
+}
+
+.palette-tr {
+  --primary: #e30a17;
+  --secondary: #ffffff;
+  --block-light: rgba(255, 255, 255, 0.3);
+  --block-dark: rgba(227, 10, 23, 0.5);
+}
+
+.theme-glass {
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
+}
+
+.theme-metal {
+  background: linear-gradient(135deg, #4b4b4b, #b5b5b5);
 }
 
 h1 {
@@ -47,13 +94,31 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: var(--gs-red);
+  background-color: var(--primary);
   color: #fff;
   cursor: pointer;
   transition: border-color 0.25s;
 }
+
+.icon-btn {
+  padding: 0.4em;
+  font-size: 1.4rem;
+  background-color: var(--primary);
+  border: none;
+  color: #fff;
+  border-radius: 8px;
+  width: 2.2rem;
+  height: 2.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-btn:hover {
+  border: 1px solid var(--secondary);
+}
 button:hover {
-  border-color: var(--gs-yellow);
+  border-color: var(--secondary);
 }
 button:focus,
 button:focus-visible {
@@ -69,7 +134,7 @@ button:focus-visible {
     color: #747bff;
   }
   button {
-    background-color: var(--gs-red);
+    background-color: var(--primary);
     color: #fff;
   }
 }


### PR DESCRIPTION
## Summary
- connect Sudoku board colors to the selected palette
- keep the app height tighter and move footer slightly
- unify icon button spacing and highlight note mode
- tweak pen cursor offset

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887ae6060ac83278d2442472a68148e