### PR TITLE
Introduce Kakuro game and new themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <footer class="footer">Developed by Mustafa Evleksiz</footer>
+    <footer class="footer">Developed by Mustafa Evleksiz v0.3.0</footer>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.css
+++ b/src/App.css
@@ -57,13 +57,21 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  justify-content: space-between;
+  width: 100%;
 }
 
-.options select,
+.options select {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  flex: 1;
+}
 .options button {
   padding: 0.5rem 1rem;
   border: 1px solid #ccc;
   border-radius: 4px;
+  width: 100%;
 }
 
 @media (min-width: 1024px) {
@@ -89,6 +97,11 @@
 }
 
 .sudoku-app {
+  justify-content: flex-start;
+  padding-top: 0.5rem;
+}
+
+.kakuro-app {
   justify-content: flex-start;
   padding-top: 0.5rem;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import './App.css'
 import SudokuGame from './SudokuGame.jsx'
+import KakuroGame from './KakuroGame.jsx'
 function generateSecret(length) {
   return Array.from({ length }, () => Math.floor(Math.random() * 10))
 }
@@ -61,7 +62,7 @@ export default function App() {
       setStatus('')
       setScreen('play')
     } else {
-      setScreen('sudoku')
+      setScreen(gameType === 'sudoku' ? 'sudoku' : 'kakuro')
     }
   }
 
@@ -154,6 +155,7 @@ export default function App() {
             <select value={gameType} onChange={(e) => setGameType(e.target.value)}>
               <option value="sudoku">Sudoku</option>
               <option value="lock">Lock Game</option>
+              <option value="kakuro">Kakuro</option>
             </select>
           </div>
           {gameType === 'lock' && (
@@ -190,6 +192,8 @@ export default function App() {
             <select value={theme} onChange={(e) => setTheme(e.target.value)}>
               <option value="glass">Bulanık Cam</option>
               <option value="metal">Metal</option>
+              <option value="wood">Ahşap</option>
+              <option value="earth">Toprak</option>
             </select>
           </div>
           <div>
@@ -212,6 +216,14 @@ export default function App() {
     return (
       <div className="app sudoku-app">
         <SudokuGame difficulty={sudokuDifficulty} onBack={handleRestart} />
+      </div>
+    )
+  }
+
+  if (screen === 'kakuro') {
+    return (
+      <div className="app kakuro-app">
+        <KakuroGame onBack={handleRestart} />
       </div>
     )
   }

--- a/src/Kakuro.css
+++ b/src/Kakuro.css
@@ -1,0 +1,4 @@
+.kakuro {
+  text-align: center;
+  animation: fadein 0.5s ease-in;
+}

--- a/src/KakuroGame.jsx
+++ b/src/KakuroGame.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import './Kakuro.css'
+
+export default function KakuroGame({ onBack }) {
+  return (
+    <div className="kakuro">
+      <h1>Kakuro</h1>
+      <p>Yeni oyun yakında burada!</p>
+      <button className="icon-btn" onClick={onBack}>🏠</button>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -82,6 +82,20 @@ body {
   background: linear-gradient(135deg, #4b4b4b, #b5b5b5);
 }
 
+.theme-wood {
+  background: repeating-linear-gradient(
+    45deg,
+    #7b4a12,
+    #7b4a12 10px,
+    #9d6520 10px,
+    #9d6520 20px
+  );
+}
+
+.theme-earth {
+  background: linear-gradient(135deg, #614126, #ad8762);
+}
+
 h1 {
   font-size: 3.2em;
   line-height: 1.1;


### PR DESCRIPTION
## Summary
- add new Kakuro game placeholder
- re-style start screen options for better alignment
- include two new themes: Ahşap and Toprak
- show app version next to footer text
- bump version to 0.3.0

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887d555c21c8327a0edb6bceca37fc4