### PR TITLE
Add games and themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <footer class="footer">Developed by Mustafa Evleksiz v0.3.0</footer>
+    <footer class="footer">Developed by Mustafa Evleksiz v0.3.1</footer>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minigames",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minigames",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react'
 import './App.css'
 import SudokuGame from './SudokuGame.jsx'
 import KakuroGame from './KakuroGame.jsx'
+import TabooGame from './TabooGame.jsx'
+import WordPuzzleGame from './WordPuzzleGame.jsx'
 function generateSecret(length) {
   return Array.from({ length }, () => Math.floor(Math.random() * 10))
 }
@@ -41,10 +43,18 @@ export default function App() {
   const [guess, setGuess] = useState([])
   const [attempts, setAttempts] = useState([])
   const [status, setStatus] = useState('')
+  const [bestScore, setBestScore] = useState(null)
 
   useEffect(() => {
     document.body.className = `theme-${theme} palette-${palette}`
   }, [theme, palette])
+
+  useEffect(() => {
+    if (gameType === 'lock') {
+      const val = localStorage.getItem(`lockBest-${mode}-${difficulty}`)
+      setBestScore(val ? parseInt(val, 10) : null)
+    }
+  }, [gameType, mode, difficulty])
 
   const finished = status !== ''
 
@@ -62,7 +72,10 @@ export default function App() {
       setStatus('')
       setScreen('play')
     } else {
-      setScreen(gameType === 'sudoku' ? 'sudoku' : 'kakuro')
+      if (gameType === 'sudoku') setScreen('sudoku')
+      else if (gameType === 'kakuro') setScreen('kakuro')
+      else if (gameType === 'taboo') setScreen('taboo')
+      else if (gameType === 'word') setScreen('word')
     }
   }
 
@@ -125,6 +138,12 @@ export default function App() {
       setAttempts(newAttempts)
       if (colors.every((c) => c === 'green')) {
         setStatus('Tebrikler! Şifre doğru.')
+        const score = newAttempts.length
+        const key = `lockBest-${mode}-${difficulty}`
+        if (bestScore === null || score < bestScore) {
+          setBestScore(score)
+          localStorage.setItem(key, score.toString())
+        }
       } else if (newAttempts.length >= maxAttempts) {
         setStatus('Deneme hakkınız bitti. Şifre: ' + secret.join(''))
       }
@@ -135,6 +154,12 @@ export default function App() {
       setAttempts(newAttempts)
       if (result.correct === codeLength) {
         setStatus('Tebrikler! Şifre doğru.')
+        const score = newAttempts.length
+        const key = `lockBest-${mode}-${difficulty}`
+        if (bestScore === null || score < bestScore) {
+          setBestScore(score)
+          localStorage.setItem(key, score.toString())
+        }
       } else if (newAttempts.length >= maxAttempts) {
         setStatus('Deneme hakkınız bitti. Şifre: ' + secret.join(''))
       }
@@ -156,6 +181,8 @@ export default function App() {
               <option value="sudoku">Sudoku</option>
               <option value="lock">Lock Game</option>
               <option value="kakuro">Kakuro</option>
+              <option value="taboo">Tabu</option>
+              <option value="word">Kelime Bulmaca</option>
             </select>
           </div>
           {gameType === 'lock' && (
@@ -191,6 +218,13 @@ export default function App() {
             <label>Tema: </label>
             <select value={theme} onChange={(e) => setTheme(e.target.value)}>
               <option value="glass">Bulanık Cam</option>
+              <option value="broken">Kırık Cam</option>
+              <option value="fabric">Kumaş</option>
+              <option value="lime">Kireç</option>
+              <option value="forest">Orman</option>
+              <option value="pastel">Pastel</option>
+              <option value="watercolor">Sulu Boya</option>
+              <option value="ocean">Okyanus</option>
               <option value="metal">Metal</option>
               <option value="wood">Ahşap</option>
               <option value="earth">Toprak</option>
@@ -228,6 +262,22 @@ export default function App() {
     )
   }
 
+  if (screen === 'taboo') {
+    return (
+      <div className="app kakuro-app">
+        <TabooGame onBack={handleRestart} />
+      </div>
+    )
+  }
+
+  if (screen === 'word') {
+    return (
+      <div className="app kakuro-app">
+        <WordPuzzleGame onBack={handleRestart} />
+      </div>
+    )
+  }
+
     return (
       <div className="app">
         <h1 className="lock-title">{mode === 'easy' ? 'LockGame Casual' : 'Lock Game Challenge'}</h1>
@@ -247,6 +297,9 @@ export default function App() {
         <button className="icon-btn" onClick={handleRestart}>🏠</button>
       </div>
       <p>Kalan Hak: {maxAttempts - attempts.length}</p>
+      {bestScore !== null && (
+        <p>Best Score: {bestScore}</p>
+      )}
       {status && <p className="status">{status}</p>}
       <div className="history">
         {attempts.map((a, idx) => (

--- a/src/Taboo.css
+++ b/src/Taboo.css
@@ -1,0 +1,4 @@
+.taboo {
+  text-align: center;
+  animation: fadein 0.5s ease-in;
+}

--- a/src/TabooGame.jsx
+++ b/src/TabooGame.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import './Taboo.css'
+
+export default function TabooGame({ onBack }) {
+  return (
+    <div className="taboo">
+      <h1>Tabu</h1>
+      <p>Yeni oyun yakında burada!</p>
+      <button className="icon-btn" onClick={onBack}>🏠</button>
+    </div>
+  )
+}

--- a/src/WordPuzzle.css
+++ b/src/WordPuzzle.css
@@ -1,0 +1,4 @@
+.word-puzzle {
+  text-align: center;
+  animation: fadein 0.5s ease-in;
+}

--- a/src/WordPuzzleGame.jsx
+++ b/src/WordPuzzleGame.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import './WordPuzzle.css'
+
+export default function WordPuzzleGame({ onBack }) {
+  return (
+    <div className="word-puzzle">
+      <h1>Kelime Bulmaca</h1>
+      <p>Yeni oyun yakında burada!</p>
+      <button className="icon-btn" onClick={onBack}>🏠</button>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -78,6 +78,35 @@ body {
   background: linear-gradient(135deg, var(--primary), var(--secondary));
 }
 
+.theme-broken {
+  background: repeating-linear-gradient(135deg, rgba(255,255,255,0.5) 0 2px, transparent 2px 4px),
+    linear-gradient(135deg, #6b8c9b, #d8e0e5);
+}
+
+.theme-fabric {
+  background: repeating-linear-gradient(45deg, #ccc, #ccc 5px, #ddd 5px, #ddd 10px);
+}
+
+.theme-lime {
+  background: linear-gradient(135deg, #e0efc0, #bfe27d);
+}
+
+.theme-forest {
+  background: linear-gradient(135deg, #2b5d34, #6fa76d);
+}
+
+.theme-pastel {
+  background: linear-gradient(135deg, #ffb3ba, #ffdfba, #ffffba, #baffc9, #bae1ff);
+}
+
+.theme-watercolor {
+  background: linear-gradient(135deg, #a2d9ff, #ffd1dc);
+}
+
+.theme-ocean {
+  background: linear-gradient(135deg, #004e92, #000428);
+}
+
 .theme-metal {
   background: linear-gradient(135deg, #4b4b4b, #b5b5b5);
 }
@@ -150,6 +179,20 @@ button:focus-visible {
   button {
     background-color: var(--primary);
     color: #fff;
+  }
+  .app {
+    background: rgba(255, 255, 255, 0.8);
+    color: #000;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+  }
+  .board {
+    background: rgba(255, 255, 255, 0.8);
+    border: 1px solid rgba(0, 0, 0, 0.2);
+  }
+  .board td,
+  .board input {
+    color: #000;
+    text-shadow: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- improve readability in light mode
- add Taboo and word puzzle placeholder games
- track best score for Lock Game
- expand theme list
- bump version to 0.3.1

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887da78bb448327adfcf0211b5d032b