### PR TITLE
Improve Kakuro input layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Her tahmin sonrası sonuçlar renklerle gösterilir:
 
 Tüm rakamlar doğru tahmin edildiğinde veya haklar bittiğinde oyun sona erer ve yeniden başlatma butonu görünür.
 
-Kakuro oyununda ise satır ve sütunlardaki toplamları kullanarak boş kareleri doğru sayılarla doldurmaya çalışırsınız.
+Kakuro oyununda ise satır ve sütunlardaki toplamları kullanarak boş kareleri doğru sayılarla doldurmaya çalışırsınız. Artık hücreler için küçük notlar bırakabilir ve yenileme düğmesine tıkladıkça rastgele sayılardan oluşan yeni bir tablo oluşturabilirsiniz. Hücre boyutları Sudoku oyunundakilerle eşleşecek şekilde güncellenmiş ve not alma sırasında yaşanan taşma sorunu giderilmiştir.
 
 ## Kurulum
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minigames",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minigames",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/src/Kakuro.css
+++ b/src/Kakuro.css
@@ -11,9 +11,13 @@
 .kakuro-board th,
 .kakuro-board td {
   border: 1px solid #ccc;
-  width: 2rem;
-  height: 2rem;
+  width: 3.3rem;
+  height: 3.3rem;
   text-align: center;
+  position: relative;
+  color: #fff;
+  text-shadow: 0 0 3px #000;
+  transition: background-color 0.3s;
 }
 
 .kakuro-board input {
@@ -22,7 +26,14 @@
   text-align: center;
   background: transparent;
   border: none;
+  font-size: 1.5rem;
+  color: #fff;
+  text-shadow: 0 0 3px #000;
+  outline: none;
+}
+.kakuro-board input:disabled {
   color: inherit;
+  -webkit-text-fill-color: inherit;
 }
 
 .block-cell {
@@ -57,4 +68,77 @@
 .status {
   margin-top: 0.5rem;
   font-weight: bold;
+}
+
+.note-cell {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  font-size: 0.7rem;
+}
+.note-cell span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0.2;
+}
+.note-cell.readonly span {
+  cursor: default;
+  opacity: 0.2;
+}
+.note-cell.readonly {
+  pointer-events: none;
+}
+.note-cell span.active {
+  color: #2196f3;
+  opacity: 1;
+}
+
+.note-btn {
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  padding: 0.4em;
+  border-radius: 8px;
+  color: var(--secondary);
+}
+.note-btn:hover {
+  border: none;
+}
+.note-btn.active {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+}
+.note-btn.inactive {
+  opacity: 0.6;
+  background: transparent;
+}
+
+@media (max-width: 600px) {
+  .kakuro-board th,
+  .kakuro-board td {
+    width: 2.6rem;
+    height: 2.6rem;
+  }
+  .kakuro-board input {
+    font-size: 1.4rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .kakuro-board th,
+  .kakuro-board td {
+    width: 4rem;
+    height: 4rem;
+  }
+  .kakuro-board input {
+    font-size: 2rem;
+  }
 }


### PR DESCRIPTION
## Summary
- clarify README about the Kakuro board improvements
- enlarge Kakuro cells and style them like Sudoku
- add responsive rules for mobile and desktop
- update lockfile version

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6887eda50558832796ff4c7ad24cb259