### PR TITLE
Implement keypad and note fixes for Kakuro

### DIFF
--- a/src/Kakuro.css
+++ b/src/Kakuro.css
@@ -3,6 +3,12 @@
   animation: fadein 0.5s ease-in;
 }
 
+.kakuro h1 {
+  margin: 0.1rem 0;
+  font-size: 1.4rem;
+  word-break: break-word;
+}
+
 .kakuro-board {
   margin: 0 auto;
   border-collapse: collapse;
@@ -119,6 +125,44 @@
 .note-btn.inactive {
   opacity: 0.6;
   background: transparent;
+}
+
+.wrong input {
+  color: #e53935;
+  -webkit-text-fill-color: #e53935;
+}
+
+.digit-pad {
+  margin-top: 0.5rem;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(8px);
+  border-radius: 10px;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+.digit-pad button {
+  width: 100%;
+  height: 3rem;
+  transition: transform 0.2s;
+  border-radius: 8px;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+}
+.digit-pad button:disabled {
+  opacity: 0.5;
+}
+.digit-pad button:active {
+  transform: scale(0.9);
+}
+
+@media (min-width: 768px) {
+  .digit-pad {
+    display: none;
+  }
 }
 
 @media (max-width: 600px) {

--- a/src/index.css
+++ b/src/index.css
@@ -128,6 +128,7 @@ body {
 h1 {
   font-size: 3.2em;
   line-height: 1.1;
+  word-break: break-word;
 }
 
 button {
@@ -200,4 +201,13 @@ button:focus-visible {
   body {
     font-size: 1.5rem;
   }
+}
+
+.info-bar span {
+  word-break: break-word;
+}
+
+.status,
+footer {
+  word-break: break-word;
 }


### PR DESCRIPTION
## Summary
- add active cell and mistake tracking for Kakuro
- implement on-screen keypad and note logic
- mark wrong entries in red and end game after 3 mistakes
- provide super mode note autofill button
- disable mobile keyboards and focus next cell automatically
- tweak global styles to avoid text overflow

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888a2001af08327b7d889fc2015d0d9