### PR TITLE
Enhance mobile layout and persistent pads

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,7 @@
 .app {
   text-align: center;
   font-family: sans-serif;
-  padding: 1rem;
+  padding: 0.5rem 1rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -100,12 +100,12 @@
 
 .sudoku-app {
   justify-content: flex-start;
-  padding-top: 0.5rem;
+  padding-top: 0.25rem;
 }
 
 .kakuro-app {
   justify-content: flex-start;
-  padding-top: 0.5rem;
+  padding-top: 0.25rem;
 }
 
 @media (max-width: 600px) {

--- a/src/Kakuro.css
+++ b/src/Kakuro.css
@@ -20,6 +20,7 @@
   width: 3.8rem;
   height: 3.8rem;
   text-align: center;
+  box-sizing: border-box;
   position: relative;
   color: #fff;
   text-shadow: 0 0 3px #000;
@@ -62,6 +63,14 @@
   display: flex;
   justify-content: center;
   gap: 0.5rem;
+}
+.controls button,
+.end-controls button {
+  width: 2.8rem;
+  height: 2.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .end-controls {
@@ -159,11 +168,6 @@
   transform: scale(0.9);
 }
 
-@media (min-width: 768px) {
-  .digit-pad {
-    display: none;
-  }
-}
 
 @media (max-width: 600px) {
   .kakuro-board th,

--- a/src/KakuroGame.jsx
+++ b/src/KakuroGame.jsx
@@ -415,20 +415,24 @@ export default function KakuroGame({ difficulty, onBack }) {
           <button className="icon-btn" onClick={onBack}>🏠</button>
         </div>
       )}
-      {activeCell && (
+      {!finished && (
         <div className="digit-pad">
           {Array.from({ length: 9 }, (_, i) => i + 1).map(n => (
             <button
               key={n}
               onPointerDown={e => e.preventDefault()}
-              onClick={() => handleChange(activeCell.r, activeCell.c, n)}
+              disabled={!activeCell}
+              onClick={() =>
+                activeCell && handleChange(activeCell.r, activeCell.c, n)
+              }
             >
               {n}
             </button>
           ))}
           <button
             onPointerDown={e => e.preventDefault()}
-            onClick={() => handleChange(activeCell.r, activeCell.c, '')}
+            disabled={!activeCell}
+            onClick={() => activeCell && handleChange(activeCell.r, activeCell.c, '')}
           >
             {'<'}
           </button>

--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -163,11 +163,6 @@
   transform: scale(0.9);
 }
 
-@media (min-width: 768px) {
-  .digit-pad {
-    display: none;
-  }
-}
 
 @media (max-width: 600px) {
   .board td {

--- a/src/SudokuGame.jsx
+++ b/src/SudokuGame.jsx
@@ -455,16 +455,18 @@ export default function SudokuGame({ difficulty, onBack }) {
           <button className="icon-btn" onClick={onBack}>🏠</button>
         </div>
       )}
-      {activeCell && (
+      {!finished && (
         <div className="digit-pad">
           {(() => {
-            const allowed = getAllowedDigits(activeCell.r, activeCell.c)
+            const allowed = activeCell ? getAllowedDigits(activeCell.r, activeCell.c) : []
             return Array.from({ length: cfg.size }, (_, i) => i + 1).map(n => (
               <button
                 key={n}
                 onPointerDown={e => e.preventDefault()}
-                disabled={!allowed.includes(n)}
-                onClick={() => handleChange(activeCell.r, activeCell.c, n)}
+                disabled={!activeCell || !allowed.includes(n)}
+                onClick={() =>
+                  activeCell && handleChange(activeCell.r, activeCell.c, n)
+                }
               >
                 {n}
               </button>
@@ -472,7 +474,8 @@ export default function SudokuGame({ difficulty, onBack }) {
           })()}
           <button
             onPointerDown={e => e.preventDefault()}
-            onClick={() => handleChange(activeCell.r, activeCell.c, '')}
+            disabled={!activeCell}
+            onClick={() => activeCell && handleChange(activeCell.r, activeCell.c, '')}
           >
             {'<'}
           </button>

--- a/src/WordPuzzle.css
+++ b/src/WordPuzzle.css
@@ -8,6 +8,19 @@
   display: flex;
   justify-content: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.controls input {
+  padding: 0.4rem;
+  font-size: 1.2rem;
+  box-sizing: border-box;
+}
+
+@media (max-width: 600px) {
+  .controls input {
+    flex: 1 1 100%;
+  }
 }
 
 .letter {


### PR DESCRIPTION
## Summary
- keep digit pads visible in Sudoku and Kakuro
- ensure they work without an active cell
- remove desktop-only media queries for pads
- improve Kakuro board layout and controls
- tweak Word Puzzle input for mobile
- adjust app padding so game titles sit higher

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6888ec471c108327b7b0090653c5edac