### PR TITLE
Enhance games and UI

### DIFF
--- a/src/Kakuro.css
+++ b/src/Kakuro.css
@@ -63,6 +63,9 @@
   display: flex;
   justify-content: center;
   gap: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
 }
 .controls button,
 .end-controls button {
@@ -78,6 +81,9 @@
   display: flex;
   justify-content: center;
   gap: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
 }
 
 .status {

--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -182,6 +182,9 @@
   display: flex;
   justify-content: center;
   gap: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
 }
 .controls button,
 .end-controls button {
@@ -197,6 +200,9 @@
   display: flex;
   justify-content: center;
   gap: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
 }
 .status {
   margin-top: 0.5rem;

--- a/src/Taboo.css
+++ b/src/Taboo.css
@@ -40,4 +40,7 @@
   justify-content: center;
   gap: 0.5rem;
   flex-wrap: wrap;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
 }

--- a/src/TabooGame.jsx
+++ b/src/TabooGame.jsx
@@ -20,6 +20,15 @@ export default function TabooGame({ onBack }) {
     { word: 'araba', taboo: ['teker', 'motor', 'yol', 'surmek', 'direksiyon'] },
     { word: 'ucak', taboo: ['kanat', 'havalimani', 'pilot', 'yolcu', 'hostes'] },
     { word: 'bisiklet', taboo: ['pedal', 'teker', 'yol', 'spor', 'surmek'] },
+    { word: 'telefon', taboo: ['arama', 'mesaj', 'rehber', 'cep', 'mobil'] },
+    { word: 'dag', taboo: ['zirve', 'yuksek', 'kar', 'kaya', 'tirmanis'] },
+    { word: 'cicek', taboo: ['bitki', 'renk', 'kok', 'bahce', 'dal'] },
+    { word: 'kirmizi', taboo: ['renk', 'kan', 'guller', 'bayrak', 'ates'] },
+    { word: 'sandalye', taboo: ['oturmak', 'masa', 'ayak', 'sirt', 'tahta'] },
+    { word: 'buzdolabi', taboo: ['soguk', 'yemek', 'mutfak', 'raf', 'kapi'] },
+    { word: 'televizyon', taboo: ['kumanda', 'ekran', 'kanal', 'haber', 'film'] },
+    { word: 'kalabalik', taboo: ['insan', 'topluluk', 'ses', 'yogun', 'cadir'] },
+    { word: 'futbol', taboo: ['top', 'gol', 'saha', 'hakem', 'takim'] },
   ]
 
   const [screen, setScreen] = useState('start')
@@ -131,6 +140,7 @@ export default function TabooGame({ onBack }) {
             <button onClick={handlePass}>Pas</button>
             <button onClick={handleCorrect}>Dogru</button>
             <button onClick={handleTaboo}>Tabu</button>
+            <button className="icon-btn" onClick={onBack}>🏠</button>
           </div>
         </>
       )}

--- a/src/Tooltip.css
+++ b/src/Tooltip.css
@@ -24,8 +24,8 @@
 }
 
 .info-tips {
-  list-style: none;
-  padding: 0;
+  list-style: decimal inside;
+  padding-left: 0.5rem;
   margin-top: 0.5rem;
   font-size: 0.85rem;
   font-style: italic;
@@ -33,6 +33,12 @@
 
 .info-tips li + li {
   margin-top: 0.25rem;
+}
+
+@media (max-width: 600px) {
+  .info-tips {
+    padding-left: 1rem;
+  }
 }
 
 .close-hint {

--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -13,11 +13,11 @@ export default function Tooltip({ info, tips = [] }) {
           <div className="info-content">
             <p>{info}</p>
             {sorted.length > 0 && (
-              <ul className="info-tips">
+              <ol className="info-tips">
                 {sorted.map((t, i) => (
                   <li key={i}>{t}</li>
                 ))}
-              </ul>
+              </ol>
             )}
             <p className="close-hint">Kapatmak için tıklayın</p>
           </div>

--- a/src/WordPuzzle.css
+++ b/src/WordPuzzle.css
@@ -9,6 +9,9 @@
   justify-content: center;
   gap: 0.5rem;
   flex-wrap: wrap;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
 }
 
 .controls input {
@@ -45,4 +48,10 @@
 .letter.gray {
   background: #999;
   color: #fff;
+}
+
+.word-length {
+  margin-top: 0.25rem;
+  font-size: 1.4rem;
+  letter-spacing: 0.3rem;
 }

--- a/src/WordPuzzleGame.jsx
+++ b/src/WordPuzzleGame.jsx
@@ -10,6 +10,7 @@ export default function WordPuzzleGame({ onBack }) {
   ].sort()
 
   const words = [
+    'ak',
     'akide',
     'bilet',
     'cihan',
@@ -18,6 +19,7 @@ export default function WordPuzzleGame({ onBack }) {
     'fidan',
     'gizem',
     'hayal',
+    'is',
     'islem',
     'kuzey',
     'lamba',
@@ -30,6 +32,24 @@ export default function WordPuzzleGame({ onBack }) {
     'tatil',
     'vagon',
     'yolcu',
+    'zengin',
+    'balon',
+    'dag',
+    'eller',
+    'gunes',
+    'hayvan',
+    'iyilik',
+    'kalem',
+    'limon',
+    'mektup',
+    'ormanlar',
+    'piramit',
+    'renk',
+    'sarmasik',
+    'toprak',
+    'uzay',
+    'yildiz',
+    'zaman',
   ]
 
   const randomWord = () => words[Math.floor(Math.random() * words.length)]
@@ -131,6 +151,9 @@ export default function WordPuzzleGame({ onBack }) {
         Kelime Bulmaca
         <Tooltip info="Harfleri kullanarak anlamli kelimeler olusturun." tips={tricks} />
       </h1>
+      <p className="word-length">
+        {Array.from({ length: wordLen }).map(() => '_').join(' ')}
+      </p>
       <div className="controls">
         {!finished && (
           <>


### PR DESCRIPTION
## Summary
- expand word pool and show hidden word length
- add more Taboo cards and show home button during play
- improve info tooltip lists for mobile
- refine button layouts across games

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888fa14a8d08327b7ebd4a018c0c661