### PR TITLE
Fix layout issues and randomize Nonogram

### DIFF
--- a/src/Nonogram.css
+++ b/src/Nonogram.css
@@ -11,8 +11,8 @@
 .nonogram-board th,
 .nonogram-board td {
   border: 1px solid #333;
-  width: 2rem;
-  height: 2rem;
+  width: calc(min(2rem, 90vw / (var(--board-size) + 2)));
+  height: calc(min(2rem, 90vw / (var(--board-size) + 2)));
   text-align: center;
   color: #fff;
   text-shadow: 0 0 3px #000;

--- a/src/WordPuzzle.css
+++ b/src/WordPuzzle.css
@@ -30,6 +30,10 @@
 .letter-pad {
   margin-top: 0.5rem;
   width: 100%;
+  max-width: 32rem;
+  margin-left: auto;
+  margin-right: auto;
+  box-sizing: border-box;
   background: rgba(255, 255, 255, 0.3);
   backdrop-filter: blur(8px);
   border-radius: 10px;
@@ -44,9 +48,9 @@
   gap: 0.25rem;
 }
 
-.letter-row.row1 { grid-template-columns: repeat(10, 1fr); }
-.letter-row.row2 { grid-template-columns: repeat(9, 1fr); }
-.letter-row.row3 { grid-template-columns: repeat(8, 1fr); }
+.letter-row.row1 { grid-template-columns: repeat(10, minmax(1.8rem, 1fr)); }
+.letter-row.row2 { grid-template-columns: repeat(9, minmax(1.8rem, 1fr)); }
+.letter-row.row3 { grid-template-columns: repeat(8, minmax(1.8rem, 1fr)); }
 
 .letter-pad button {
   width: 100%;


### PR DESCRIPTION
## Summary
- tweak mobile keyboard styles so rows fit small screens
- scale Nonogram board for mobile and allow random board generation
- regenerate puzzle when difficulty changes or restarting a game

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688934ca2d5c8327b037a6e235aa0486